### PR TITLE
ci: add bruno-drift-check step to docker-smoke (ALP-1010)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,17 @@ jobs:
             sleep 2
           done
 
+      # No bru run here (yet): this repo has no bruno/ collection committed to
+      # main today (ALP-1010 found the only copy in an orphaned, never-pushed
+      # local branch elsewhere) -- bruno-drift-check gracefully SKIPPED/exit 0
+      # in that state (tools/bruno-drift-check/README.md), so it's safe to
+      # wire now and it'll start reporting real drift once a bruno/ collection
+      # lands on main. See ALP-1010 for the orphaned-branch discovery.
+      - name: Bruno collection drift check
+        run: |
+          pip install "bruno-drift-check @ git+https://github.com/dabeezor/alpha-technology.git#subdirectory=tools/bruno-drift-check"
+          bruno-drift-check .
+
       - name: Show container logs on failure
         if: failure()
         shell: bash


### PR DESCRIPTION
## Summary
- Adds a `bruno-drift-check` step to the existing `docker-smoke` job, right after the API health check.
- No `bru run` step yet: this repo has no `bruno/` collection committed to `main` today (a Bruno collection + `API_TOKEN` auth gate exist only in an orphaned, never-pushed local branch elsewhere — flagged separately, not included in this PR). `bruno-drift-check` gracefully reports SKIPPED (exit 0) when it finds no `bruno/` directory, so this is safe to land now and will start reporting real drift once a collection lands on `main`.

## Test plan
- [ ] CI run green on this PR (gate → docker-smoke, including the new drift-check step reporting SKIPPED)

Part of ALP-1010 (internal tracking).