### PR TITLE
fix(studio): keep rc/rl run tags in LoRA labels

### DIFF
--- a/backend/app/services/lora_training.py
+++ b/backend/app/services/lora_training.py
@@ -4474,8 +4474,9 @@ def _custom_combo_hash(ds, base_model=_PERSISTED, family=None) -> str:
 # silently replaced A's LoRA). Cloud runs tag with their CloudTrainingRun id
 # (`_rc49`), local runs with their TrainingRunRecord id (`_rl12`) — matching the
 # ☁/💻 #N chips on the Runs page. Parsed back out (parse_deployed_run) so the
-# "in ComfyUI" list can show each file's source run. It is stripped from display
-# labels (comfyui._parse_trained_stem) so it reads as a chip, not name noise.
+# "in ComfyUI" list can show each file's source run. Display labels also keep
+# the raw `rcN`/`rlN` token (comfyui.format_trained_lora_label) so Test Studio
+# can tell two same-version runs apart where no chip is shown.
 _DEPLOYED_RUN_TAG_RE = re.compile(r'_r([cl])(\d+)(?:_v\d+)?(?:\.[^.]+)?$')
 
 

--- a/backend/app/utils/comfyui.py
+++ b/backend/app/utils/comfyui.py
@@ -1498,8 +1498,10 @@ def free_comfyui_vram(worker_url=None, timeout=10) -> ComfyVramFreeVerdict:
 # tout-chiffres de 4+ caractères = un compteur de steps (pas une version 'v13').
 _TRAINED_STEP_RE = re.compile(r'^\d{4,}$')
 # Source-run tag token: `rc<id>` (cloud CloudTrainingRun id) / `rl<id>` (local
-# TrainingRunRecord id) appended by lora_training.import_checkpoint. It carries
-# run identity for the ☁/💻 #N chips, so it is stripped from display labels.
+# TrainingRunRecord id) appended by lora_training.import_checkpoint. Kept out of
+# the base/merge token list (so it is not mistaken for a recipe tag) and
+# re-appended at the END of the display label — without it, two runs of the same
+# dataset version collapse to one identical Test Studio name.
 _RUN_TAG_TOKEN_RE = re.compile(r'^r[cl]\d+$')
 
 # Familles d'entraînement (= pipeline). La clé interne ('zimage'/'sdxl'/'krea') et
@@ -1562,18 +1564,18 @@ def family_of_lora(filename: str) -> str | None:
 
 def _finish_parse(trigger: str, rest_tokens):
     """Partage final du parse : depuis un trigger déjà isolé et les tokens qui le
-    SUIVENT, extrait le step (1er token tout-chiffres 4+) et le reste (base/merge),
-    en jetant le tag de run `rc<id>`/`rl<id>` (surfacé en chip ☁/💻 #N, pas du bruit
-    de label)."""
-    step, rest = None, []
+    SUIVENT, extrait le step (1er token tout-chiffres 4+), le reste (base/merge)
+    et le tag de run `rc<id>`/`rl<id>` (identité du run — rendu en fin de label
+    pour que deux runs de la même version dataset restent distincts)."""
+    step, rest, run_tag = None, [], None
     for t in rest_tokens:
         if step is None and _TRAINED_STEP_RE.match(t):
             step = int(t)
         elif _RUN_TAG_TOKEN_RE.match(t):
-            continue
+            run_tag = t
         else:
             rest.append(t)
-    return trigger, step, rest
+    return trigger, step, rest, run_tag
 
 
 def _parse_trained_stem(filename: str, trigger: str | None = None):
@@ -1620,9 +1622,18 @@ def _parse_trained_stem(filename: str, trigger: str | None = None):
     if step_idx is not None and step_idx > 0:
         return _finish_parse('_'.join(tokens[:step_idx]), tokens[step_idx:])
 
-    # 3) Pas de step : tag de base de famille en fin → trigger = tout ce qui précède.
-    if len(tokens) > 1 and tokens[-1] in _FAMILY_BASE_TAGS:
-        return _finish_parse('_'.join(tokens[:-1]), [tokens[-1]])
+    # 3) Pas de step : tag de base de famille, éventuellement suivi du tag de
+    #    run (`rcN`/`rlN`) et du suffixe de version (`vN`) — le trigger = tout
+    #    ce qui précède le tag de base. Sans peler ces suffixes, un final
+    #    `…_Krea-2-Raw_rc27_v2` tombait dans le repli legacy et tronquait les
+    #    triggers multi-token (`leg_behind` → `leg`).
+    core = list(tokens)
+    peeled = []
+    while core and (re.fullmatch(r'v\d+', core[-1])
+                    or _RUN_TAG_TOKEN_RE.match(core[-1])):
+        peeled.insert(0, core.pop())
+    if len(core) > 1 and core[-1] in _FAMILY_BASE_TAGS:
+        return _finish_parse('_'.join(core[:-1]), [core[-1], *peeled])
 
     # 4) Repli legacy : premier token = trigger.
     return _finish_parse(tokens[0], tokens[1:])
@@ -1638,18 +1649,22 @@ def trained_lora_group(filename: str, family: str | None = None,
 
     La clé = le displayName AMPUTÉ du segment « N steps » → cohérente avec le label
     affiché (cf. format_trained_lora_label) : le checkpoint final (sans step) a un
-    displayName EXACTEMENT égal à la clé de son groupe. `trigger` (optionnel) = le
+    displayName EXACTEMENT égal à la clé de son groupe. Le tag de run (`rc27` /
+    `rl12`) fait partie de la clé : deux runs de la même version dataset ne
+    doivent pas s'empiler sous une seule entrée. `trigger` (optionnel) = le
     trigger réel du dataset pour un parse EXACT (cf. _parse_trained_stem)."""
     parsed = _parse_trained_stem(filename, trigger)
     if not parsed:
         return None, None
-    trigger, step, rest = parsed
+    trigger, step, rest, run_tag = parsed
     if rest:
         base = ' '.join(rest)
     else:
         fam = family or family_of_lora(filename)
         base = FAMILY_LABELS.get(fam, fam) if fam else ''
     group = f'{trigger} · {base}' if base else trigger
+    if run_tag:
+        group = f'{group} · {run_tag}'
     return group, step
 
 
@@ -1660,8 +1675,10 @@ def format_trained_lora_label(filename: str, family: str | None = None,
 
     Le step est zero-paddé à 9 chiffres (``000004000``) ; affiché brut il se lit
     comme du bruit et rend deux checkpoints frères indiscernables. On expose les
-    axes que l'utilisateur compare : le trigger, le step dé-paddé (``4000``) et la
-    base d'entraînement. Cette base apparaît dans le nom sous forme de tag de merge
+    axes que l'utilisateur compare : le trigger, le step dé-paddé (``4000``), la
+    base d'entraînement, et le tag de run (`rc27` / `rl12`) quand il est présent —
+    sans lui, deux runs déployés de la même version dataset portent le même nom
+    dans le Test Studio. Cette base apparaît dans le nom sous forme de tag de merge
     (``bigLove_zt3``) ; QUAND ce tag est absent (LoRA entraîné sur la base officielle
     de la famille, ex. ``lora_Lola2_000002000`` en Krea), on affiche au moins la
     PIPELINE (Krea 2 / SDXL / Z-Image) — sinon on ne sait pas avec quoi il a été fait.
@@ -1676,11 +1693,12 @@ def format_trained_lora_label(filename: str, family: str | None = None,
         'krea/lora_Lola2_000002000' (family krea)  -> 'Lola2 · 2000 steps · Krea 2'
         'sdxl/lora_Lola2_mopMix_pornmaster'        -> 'Lola2 · mopMix pornmaster'
         'lora_leg_behind_000002000_Krea-2-Turbo'   -> 'leg_behind · 2000 steps · Krea 2'
+        '…_Krea-2-Raw_rc27_v2'                    -> '… · Krea-2-Raw v2 · rc27'
     """
     parsed = _parse_trained_stem(filename, trigger)
     if not parsed:
         return ''
-    trigger, step, rest = parsed
+    trigger, step, rest, run_tag = parsed
     parts = [trigger]
     if step is not None:
         parts.append(f'{step} steps')
@@ -1690,6 +1708,8 @@ def format_trained_lora_label(filename: str, family: str | None = None,
         fam = family or family_of_lora(filename)     # pas de tag -> au moins la pipeline
         if fam:
             parts.append(FAMILY_LABELS.get(fam, fam))
+    if run_tag:
+        parts.append(run_tag)
     return ' · '.join(parts)
 
 

--- a/backend/tests/test_comfyui_utils.py
+++ b/backend/tests/test_comfyui_utils.py
@@ -167,6 +167,37 @@ def test_underscore_trigger_siblings_group_together():
     assert (sa, sb) == (2000, 2500)
 
 
+def test_run_tag_distinguishes_same_dataset_version():
+    """Two cloud runs of the same dataset version deploy as `…_rc15_v2` and
+    `…_rc27_v2`. Without the run tag in the label, Test Studio shows the same
+    name twice and the user cannot tell which epoch is the winner."""
+    a = r'krea\lora_nova_000002000_Krea-2-Raw_rc15_v2.safetensors'
+    b = r'krea\lora_nova_000002000_Krea-2-Raw_rc27_v2.safetensors'
+    assert format_trained_lora_label(a, 'krea') == (
+        'nova · 2000 steps · Krea-2-Raw v2 · rc15')
+    assert format_trained_lora_label(b, 'krea') == (
+        'nova · 2000 steps · Krea-2-Raw v2 · rc27')
+    ga, _ = trained_lora_group(a, 'krea')
+    gb, _ = trained_lora_group(b, 'krea')
+    assert ga != gb
+    assert ga == 'nova · Krea-2-Raw v2 · rc15'
+    assert gb == 'nova · Krea-2-Raw v2 · rc27'
+    # Epochs of the SAME run still share one expandable group.
+    c = r'krea\lora_nova_000002500_Krea-2-Raw_rc27_v2.safetensors'
+    assert trained_lora_group(c, 'krea')[0] == gb
+    assert '2500' in format_trained_lora_label(c, 'krea')
+
+
+def test_run_tag_on_final_keeps_underscore_trigger():
+    """A step-less final carrying `_rcN_vN` after the family base tag must still
+    recover a multi-token trigger — the suffixes are peeled before the base-tag
+    anchor, not mistaken for part of the trigger."""
+    f = r'krea\lora_leg_behind_Krea-2-Turbo_rl5_v1.safetensors'
+    assert format_trained_lora_label(f, 'krea') == (
+        'leg_behind · Krea-2-Turbo v1 · rl5')
+    assert trained_lora_group(f, 'krea')[0] == 'leg_behind · Krea-2-Turbo v1 · rl5'
+
+
 def test_underscore_trigger_final_checkpoint_uses_family_tag():
     """The FINAL checkpoint carries no step, only a family base tag
     (`lora_leg_behind_Krea-2-Turbo`). Recognizing the known tag still recovers the


### PR DESCRIPTION
## What & why

In Test Studio, two deployed LoRAs from different cloud runs of the **same** dataset version looked identical — e.g. both showed as `nova · 2000 steps · Krea-2-Raw v2`. The run identity (`rc15` / `rc27`) was already in the filename so the files never collided, but `format_trained_lora_label` stripped that tag on purpose (it was meant for ☁/💻 chips elsewhere). Test Studio never shows those chips, so you could not tell which run an epoch belonged to when picking a winner.

This keeps `rcN` / `rlN` at the end of the label and the LoRA group key (`… · rc27`), so same-version runs stay distinguishable. Also peels trailing run/version suffixes before the family base-tag anchor, so a step-less final like `…_Krea-2-Turbo_rl5_v1` still recovers multi-token triggers instead of truncating them.

No issue opened — caught while comparing two same-version deploys in Test Studio.

## How I tested

- [x] `python -m pytest backend/tests/test_comfyui_utils.py -q` passes (includes new cases for same-version run tags and finals with `_rlN_vN`)
- [ ] `python -m pytest backend/tests -q` passes
- [ ] Frontend `npm run build` succeeds **and I committed the regenerated `frontend/dist/`** (only if I touched `frontend/src`)
- [x] N/A for frontend build — backend-only label/parse change; no `frontend/src` touch

## Screenshots

### Before
<img width="689" height="557" alt="image" src="https://github.com/user-attachments/assets/e33d28a7-8998-4317-8734-db720111c7e6" />

### After
<img width="686" height="557" alt="image" src="https://github.com/user-attachments/assets/47b2ef6b-5dd2-4d53-9c2b-b06e1f133e90" />


## Checklist

- [x] Small and focused — one change per PR
- [x] UI text is in English
- [x] **No secrets or local paths** in the code, screenshots, logs, or this description (no API keys, tokens, `config.json`, `.env`, absolute machine paths)
- [x] I read the [Contributing guide](../CONTRIBUTING.md)