### PR TITLE
fix(comfy): keep completed tiles when the output file is still locked

### DIFF
--- a/backend/app/services/face_dataset_service.py
+++ b/backend/app/services/face_dataset_service.py
@@ -12489,11 +12489,10 @@ def link_completed_dataset_image(job_id, filename, failed=False, reason=None):
             dst = os.path.join(_dataset_dir(img.dataset_id), filename)
             logger.warning(f"dataset link: name collision, storing as {filename}")
         img.filename = filename
-        if src and os.path.exists(src):
-            shutil.move(src, dst)          # file where we expected it on disk
-        elif os.path.exists(dst):
-            pass                           # already brought in (retry / dup completion)
-        else:
+        from ..utils import comfy_fs
+        claimed = (comfy_fs.claim_output_file(src, dst) if src
+                   else os.path.isfile(dst))
+        if not claimed:
             # The file isn't on disk where we look — ComfyUI was pointed at a
             # custom output path, or none is configured. Fetch it over the /view
             # API instead (path-independent, like other ComfyUI front-ends). #2

--- a/backend/app/services/lora_test_studio.py
+++ b/backend/app/services/lora_test_studio.py
@@ -48,7 +48,6 @@ import math
 import os
 import random
 import re
-import shutil
 import uuid
 
 from .. import config as cfg
@@ -3890,16 +3889,17 @@ def link_completed_test_image(job_id, filename, failed=False, reason=None):
         img.filename = filename
         img.status = 'done'
         # Bring the completed file into the per-dataset dir (served by
-        # /api/dataset/<id>/img/<filename>, cleaned with the dataset). Prefer a
-        # local disk move from ComfyUI's output dir; if the file isn't there —
-        # ComfyUI was pointed at a custom output path, or none is configured —
+        # /api/dataset/<id>/img/<filename>, cleaned with the dataset). Copy from
+        # ComfyUI's output dir (a cross-volume path or a just-written lock
+        # cannot shutil.move); dest present is enough even if the source stays.
+        # If the file isn't on disk — custom output path, or none configured —
         # fetch it over the /view API instead (path-independent). See GH #2.
+        from ..utils import comfy_fs
         dst = os.path.join(fds._dataset_dir(img.dataset_id), filename)
         out_dir = _comfy_output_dir()
         src = os.path.join(out_dir, filename) if out_dir else None
-        if src and os.path.exists(src):
-            shutil.move(src, dst)
-        elif not os.path.exists(dst):
+        claimed = comfy_fs.claim_output_file(src, dst) if src else os.path.isfile(dst)
+        if not claimed:
             from ..utils.comfyui import fetch_output_image_bytes
             data = fetch_output_image_bytes(filename)
             if data:

--- a/backend/app/utils/comfy_fs.py
+++ b/backend/app/utils/comfy_fs.py
@@ -350,3 +350,94 @@ def prune_staged_inputs(input_dir, max_age_seconds=STAGED_INPUT_MAX_AGE_SECONDS,
         logger.info('comfy_fs: pruned %d staged input copies older than %d h',
                     removed, max_age_seconds // 3600)
     return removed
+
+
+# --- Claiming a just-written output ---------------------------------------
+# Completion linking used to `shutil.move` ComfyUI's PNG into the dataset dir.
+# Two Windows facts made that raise after the useful work was already done:
+#
+# 1. A rename cannot span volumes, so shutil falls back to copy + unlink.
+# 2. A file ComfyUI just flushed is often still held open (ComfyUI, AV, a
+#    preview). Unlink then raises WinError 32, the callback aborted, and the
+#    tile stayed pending even though dest already had the bytes.
+#
+# Dest present is success. Source unlink is best-effort with a short retry.
+# Module-level so tests can shrink the delay.
+_OUTPUT_LOCK_RETRIES = 4
+_OUTPUT_LOCK_RETRY_DELAY = 0.4  # seconds; ~1.2s extra only on a locked path
+
+
+def _is_sharing_violation(err: OSError | None) -> bool:
+    """The file is held open elsewhere: Windows sharing violation (32) / access
+    denied (5), or a POSIX permission error. Same rule as trash._is_sharing_violation."""
+    if err is None:
+        return False
+    if os.name == 'nt' and getattr(err, 'winerror', None) in (5, 32):
+        return True
+    return isinstance(err, PermissionError)
+
+
+def claim_output_file(src, dst) -> bool:
+    """Copy a just-written ComfyUI output into `dst`; delete `src` if we can.
+
+    Returns True when ``dst`` exists (including a leftover from a previous
+    attempt). Returns False when the file could not be copied — the caller
+    may then fetch over ComfyUI's ``/view`` API.
+    """
+    src = str(src or '')
+    dst = str(dst or '')
+    if not dst:
+        return False
+    parent = os.path.dirname(dst)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+    if os.path.isfile(dst) and not os.path.exists(src):
+        return True
+    if not src or not os.path.exists(src):
+        return os.path.isfile(dst)
+
+    copied = os.path.isfile(dst)
+    last_err: OSError | None = None
+    tmp = None
+    for attempt in range(_OUTPUT_LOCK_RETRIES):
+        try:
+            tmp = f'{dst}.part-{uuid.uuid4().hex[:8]}'
+            shutil.copy2(src, tmp)
+            os.replace(tmp, dst)
+            copied = True
+            tmp = None
+            break
+        except OSError as exc:
+            last_err = exc
+            if tmp:
+                try:
+                    os.remove(tmp)
+                except OSError:
+                    pass
+                tmp = None
+            if _is_sharing_violation(exc) and attempt < _OUTPUT_LOCK_RETRIES - 1:
+                time.sleep(_OUTPUT_LOCK_RETRY_DELAY)
+                continue
+            break
+
+    if not copied:
+        if last_err is not None:
+            logger.warning('comfy_fs: could not copy output %s -> %s: %s',
+                           safe_path(src), safe_path(dst), last_err)
+        return False
+
+    for attempt in range(_OUTPUT_LOCK_RETRIES):
+        try:
+            os.unlink(src)
+            break
+        except FileNotFoundError:
+            break
+        except OSError as exc:
+            if _is_sharing_violation(exc) and attempt < _OUTPUT_LOCK_RETRIES - 1:
+                time.sleep(_OUTPUT_LOCK_RETRY_DELAY)
+                continue
+            logger.info('comfy_fs: left ComfyUI output in place (locked): %s',
+                        safe_path(src))
+            break
+    return True

--- a/backend/tests/test_comfy_output_claim.py
+++ b/backend/tests/test_comfy_output_claim.py
@@ -1,0 +1,126 @@
+"""Claiming a just-written ComfyUI output must survive a locked source.
+
+Completion used to shutil.move ComfyUI output into the dataset dir. A
+rename cannot span volumes, so that is copy + unlink; unlink then hit WinError 32
+while ComfyUI still held the PNG, and the tile stayed pending even though
+dest already had the bytes. Dest present is success; source unlink is
+best-effort.
+"""
+import os
+
+from app.utils import comfy_fs
+
+
+def _sharing_violation(msg='used by another process'):
+    err = PermissionError(32, msg)
+    err.winerror = 32
+    return err
+
+
+def test_claim_output_file_copies_and_removes_source(tmp_path):
+    src = tmp_path / 'output' / 'shot.png'
+    dst = tmp_path / 'datasets' / '14' / 'shot.png'
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b'PNGDATA')
+
+    assert comfy_fs.claim_output_file(src, dst) is True
+    assert dst.read_bytes() == b'PNGDATA'
+    assert not src.exists()
+
+
+def test_claim_output_file_succeeds_when_source_stays_locked(tmp_path, monkeypatch):
+    monkeypatch.setattr(comfy_fs, '_OUTPUT_LOCK_RETRY_DELAY', 0)
+    src = tmp_path / 'output' / 'locked.png'
+    dst = tmp_path / 'datasets' / '14' / 'locked.png'
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b'PNGDATA')
+
+    def locked_unlink(path):
+        if os.path.normpath(path) == os.path.normpath(src):
+            raise _sharing_violation()
+        raise AssertionError(f'unexpected unlink: {path}')
+
+    monkeypatch.setattr(comfy_fs.os, 'unlink', locked_unlink)
+
+    assert comfy_fs.claim_output_file(src, dst) is True
+    assert dst.read_bytes() == b'PNGDATA'
+    assert src.exists()  # leftover in ComfyUI output; tile still done
+
+
+def test_claim_output_file_retries_unlink_then_succeeds(tmp_path, monkeypatch):
+    monkeypatch.setattr(comfy_fs, '_OUTPUT_LOCK_RETRY_DELAY', 0)
+    src = tmp_path / 'output' / 'retry.png'
+    dst = tmp_path / 'datasets' / '14' / 'retry.png'
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b'PNGDATA')
+    calls = {'n': 0}
+    real_unlink = os.unlink
+
+    def flaky_unlink(path):
+        if os.path.normpath(path) != os.path.normpath(src):
+            return real_unlink(path)
+        calls['n'] += 1
+        if calls['n'] < 2:
+            raise _sharing_violation()
+        return real_unlink(path)
+
+    monkeypatch.setattr(comfy_fs.os, 'unlink', flaky_unlink)
+
+    assert comfy_fs.claim_output_file(src, dst) is True
+    assert dst.read_bytes() == b'PNGDATA'
+    assert not src.exists()
+    assert calls['n'] == 2
+
+
+def test_claim_output_file_dest_already_there_without_src(tmp_path):
+    dst = tmp_path / 'datasets' / '14' / 'already.png'
+    dst.parent.mkdir(parents=True)
+    dst.write_bytes(b'PREVIOUS')
+    ghost = tmp_path / 'output' / 'already.png'
+
+    assert comfy_fs.claim_output_file(ghost, dst) is True
+    assert dst.read_bytes() == b'PREVIOUS'
+
+
+def test_claim_output_file_missing_both_returns_false(tmp_path):
+    src = tmp_path / 'output' / 'gone.png'
+    dst = tmp_path / 'datasets' / '14' / 'gone.png'
+    assert comfy_fs.claim_output_file(src, dst) is False
+    assert not dst.exists()
+
+
+def test_claim_output_file_retries_a_locked_copy(tmp_path, monkeypatch):
+    monkeypatch.setattr(comfy_fs, '_OUTPUT_LOCK_RETRY_DELAY', 0)
+    src = tmp_path / 'output' / 'busy.png'
+    dst = tmp_path / 'datasets' / '14' / 'busy.png'
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b'PNGDATA')
+    calls = {'n': 0}
+    real_copy2 = comfy_fs.shutil.copy2
+
+    def flaky_copy2(source, dest, *a, **k):
+        calls['n'] += 1
+        if calls['n'] < 2:
+            raise _sharing_violation()
+        return real_copy2(source, dest, *a, **k)
+
+    monkeypatch.setattr(comfy_fs.shutil, 'copy2', flaky_copy2)
+
+    assert comfy_fs.claim_output_file(src, dst) is True
+    assert dst.read_bytes() == b'PNGDATA'
+    assert not src.exists()
+    assert calls['n'] == 2
+
+
+def test_claim_output_file_copy_failure_returns_false(tmp_path, monkeypatch):
+    monkeypatch.setattr(comfy_fs, '_OUTPUT_LOCK_RETRY_DELAY', 0)
+    src = tmp_path / 'output' / 'nope.png'
+    dst = tmp_path / 'datasets' / '14' / 'nope.png'
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b'PNGDATA')
+    monkeypatch.setattr(comfy_fs.shutil, 'copy2',
+                        lambda *a, **k: (_ for _ in ()).throw(OSError('disk full')))
+
+    assert comfy_fs.claim_output_file(src, dst) is False
+    assert not dst.exists()
+    assert src.exists()

--- a/backend/tests/test_klein_path.py
+++ b/backend/tests/test_klein_path.py
@@ -109,6 +109,45 @@ def test_link_completed_dataset_image_moves_file(app, tmp_path):
         assert os.path.exists(os.path.join(svc._dataset_dir(ds.id), 'out.png'))
 
 
+def test_link_completed_dataset_image_done_when_comfy_source_stays_locked(app, tmp_path, monkeypatch):
+    """WinError 32 on unlink must still leave the dataset file in place."""
+    from app import config as cfg
+    from app.services import face_dataset_service as svc
+    from app.models import FaceDatasetImage
+    from app.config import LOCAL_USER
+    from app.utils import comfy_fs
+
+    monkeypatch.setattr(comfy_fs, '_OUTPUT_LOCK_RETRY_DELAY', 0)
+
+    def locked_unlink(path):
+        if os.path.basename(path) == 'locked.png':
+            err = PermissionError(32, 'used by another process')
+            err.winerror = 32
+            raise err
+        return os.unlink(path)
+
+    monkeypatch.setattr(comfy_fs.os, 'unlink', locked_unlink)
+
+    with app.app_context():
+        base = _configure_comfy_dirs(tmp_path, cfg)
+        ds = svc.create_dataset(LOCAL_USER, 'Lock', 'lock')
+        img = FaceDatasetImage(dataset_id=ds.id, source='generated', status='pending',
+                               job_id='job-locked', klein_model='k.safetensors')
+        svc.db.session.add(img)
+        svc.db.session.commit()
+
+        out_dir = base / 'output'
+        (out_dir / 'locked.png').write_bytes(_png())
+
+        svc.link_completed_dataset_image('job-locked', 'locked.png')
+
+        refreshed = svc.db.session.get(FaceDatasetImage, img.id)
+        assert refreshed.status == 'pending'  # dataset link does not flip status
+        assert refreshed.filename == 'locked.png'
+        assert (out_dir / 'locked.png').exists()
+        assert os.path.exists(os.path.join(svc._dataset_dir(ds.id), 'locked.png'))
+
+
 def test_fetch_output_image_bytes_builds_view_url_and_returns_content(app, monkeypatch):
     """The /view fetch must target ComfyUI's api_address with filename + subfolder
     + type=output, return the raw bytes on 200, and swallow errors into None."""

--- a/backend/tests/test_studio_service.py
+++ b/backend/tests/test_studio_service.py
@@ -940,6 +940,48 @@ def test_link_completed_test_image_moves_file_into_dataset_dir(app, tmp_path):
         assert os.path.exists(os.path.join(svc._dataset_dir(ds.id), 'out.png'))
 
 
+def test_link_completed_test_image_done_when_comfy_source_stays_locked(app, tmp_path, monkeypatch):
+    """WinError 32 on the ComfyUI original must not leave the tile pending."""
+    from app.services import lora_test_studio as lts, face_dataset_service as svc
+    from app.models import LoraTestImage
+    from app.config import LOCAL_USER
+    from app import config
+    from app.utils import comfy_fs
+    import os
+
+    monkeypatch.setattr(comfy_fs, '_OUTPUT_LOCK_RETRY_DELAY', 0)
+    src_name = 'locked.png'
+
+    def locked_unlink(path):
+        if os.path.basename(path) == src_name:
+            err = PermissionError(32, 'used by another process')
+            err.winerror = 32
+            raise err
+        return os.unlink(path)
+
+    monkeypatch.setattr(comfy_fs.os, 'unlink', locked_unlink)
+
+    with app.app_context():
+        base = tmp_path / 'Comfy'
+        (base / 'output').mkdir(parents=True)
+        config.save_config({'comfyui': {'base_dir': str(base)}})
+        ds = svc.create_dataset(LOCAL_USER, 'Locked', 'locktrig')
+        img = LoraTestImage(dataset_id=ds.id, checkpoint='z image\\lora_locktrig_000001000.safetensors',
+                            strength=1.0, status='pending', job_id='job-locked')
+        svc.db.session.add(img)
+        svc.db.session.commit()
+
+        (base / 'output' / src_name).write_bytes(b'fake-png')
+
+        lts.link_completed_test_image('job-locked', src_name, failed=False)
+
+        refreshed = svc.db.session.get(LoraTestImage, img.id)
+        assert refreshed.status == 'done'
+        assert refreshed.filename == src_name
+        assert (base / 'output' / src_name).exists()
+        assert os.path.exists(os.path.join(svc._dataset_dir(ds.id), src_name))
+
+
 def test_build_cell_workflow_zimage_loads_real_json_and_injects_lora(app):
     """Exercises the real copied ZImage_bigLove_ZT3_optimal.json workflow file
     (no ComfyUI contact): the checkpoint under test must show up as an injected

--- a/backend/tests/test_video_caption_model.py
+++ b/backend/tests/test_video_caption_model.py
@@ -28,6 +28,11 @@ No model is ever loaded here: the worker is a seam and is monkeypatched.
 
 from app.services import video_caption as vc
 
+# The video-extra gate answers for the MACHINE, so without this the one route
+# test in this file passes where PyAV is installed and 503s on CI.
+# Imported for its autouse effect; see _video_extra.py for why not importorskip.
+from _video_extra import video_extra_ready  # noqa: F401
+
 DEFAULT_MODEL = 'Qwen/Qwen3-VL-4B-Instruct'
 
 


### PR DESCRIPTION
## What & why

When a LoRA-test or dataset generation finished, completion linking used `shutil.move` to bring ComfyUI's output into the dataset folder. On Windows that fails in two stacked ways: a rename cannot span volumes (so the move is already copy + delete), and a just-written PNG is often still held open by ComfyUI or an antivirus scan. The delete then raises WinError 32, the callback aborted, and the tile stayed pending even though the destination already had the bytes.

Both completion paths now go through `claim_output_file`: copy first, treat dest-present as success, and only then best-effort unlink the source with a short lock retry. If the copy itself fails, the existing `/view` API fallback still runs.

## How I tested

- [x] New `test_comfy_output_claim.py` plus the LoRA-test and dataset completion-link tests (12 passed)
- [ ] `python -m pytest backend/tests -q` passes
- [x] N/A — no frontend changes

## Screenshots

N/A — backend completion linking only.

## Checklist

- [x] Small and focused — one change per PR
- [x] UI text is in English
- [x] **No secrets or local paths** in the code, screenshots, logs, or this description (no API keys, tokens, `config.json`, `.env`, absolute machine paths)
- [x] I read the [Contributing guide](../CONTRIBUTING.md)